### PR TITLE
Fixed warnings on `@inlinable` functions

### DIFF
--- a/Sources/SwiftyTable/Extensions/IndexPath+Extension.swift
+++ b/Sources/SwiftyTable/Extensions/IndexPath+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by Yusaku Nishi on 2018/09/26.
 //
 
-import Foundation
+import UIKit
 
 public extension IndexPath {
     


### PR DESCRIPTION
# Maintenance

- Fixed to import UIKit to use `IndexPath.init(row:section:)` in `@inlinable` functions.
  
  <img width="953" alt="warning" src="https://github.com/jrsaruo/SwiftyTable/assets/23174349/852d828f-c36c-4ffe-8fe1-f63227101c0f">
